### PR TITLE
fixed race condition bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,4 @@
 ## Usage tutorial
 
 - [Jimmy Berry (version 0.3.1)](https://www.youtube.com/watch?v=T0ryc7kJzZA)
+- [César Lorenzon (version 0.3.3)](https://youtu.be/rTG_1kPb8g4)

--- a/__init__.py
+++ b/__init__.py
@@ -23,12 +23,14 @@ import random
 bl_info = {
     'name': 'Typewriter Text',
     'description': 'Typewriter Text effect for font objects',
-    'author': 'Bassam Kurdali, Vilem Novak, Jimmy Berry',
-    'version': (0, 3, 2),
+    'author': 'Bassam Kurdali, Vilem Novak, Jimmy Berry, doakey3, gandalf3, cesarl94',
+    'version': (0, 3, 3),
     'blender': (2, 80, 0),
-    'location': 'Properties Editor, Text Context',
+    'location': 'Properties Editor > Text Context',
     'url': 'https://github.com/boombatower/blender-typewriter-addon',
-    'category': 'Text'}
+    'support':'COMMUNITY',
+    'category': 'Object'
+}
 
 
 def randomize(t,width):
@@ -53,12 +55,12 @@ def uptext(text, eval_text):
     slice the source text up to the character_count
     '''
 
-    source = text.source_text
+    source = eval_text.source_text
     if source in bpy.data.texts:
-        if text.separator!='':    strings=bpy.data.texts[source].as_string().split(text.separator)
+        if eval_text.separator!='':    strings=bpy.data.texts[source].as_string().split(eval_text.separator)
         else:
             strings=[bpy.data.texts[source].as_string()]
-        idx=min(len(strings),text.text_index)
+        idx=min(len(strings),eval_text.text_index)
         t=strings[idx]
 
         #remove line endings after separator


### PR DESCRIPTION
Problem:
![Animation](https://github.com/doakey3/blender-typewriter-addon/assets/31864321/e123cf0a-abc9-4a18-8530-80b33756a126)
Output frames: 
![frames](https://github.com/doakey3/blender-typewriter-addon/assets/31864321/6d578286-ed27-47d1-a760-03c8c9fb335c)
The red frame is duplicated, the orange ones are out of sync, and the green one is the only one that is correct

My solution:
I addressed a race condition bug that was causing occasional duplication of frames in the application. The issue stemmed from incorrect data being read, leading to frames being duplicated when they shouldn't be. After investigating the problem, I found that the root cause was a race condition, as outlined in the Blender documentation (https://docs.blender.org/api/current/bpy.app.handlers.html). Specifically, altering data from handlers needed to be handled carefully due to the threading model used in the application.

To resolve the issue, I made a change to the variable responsible for reading and updating the data of the displayed text to ensure it was done correctly. By using the appropriate variable, we prevent the race condition and ensure the correct data is displayed without duplication of frames.

This commit provides a comprehensive fix for the race condition bug, ensuring smoother and more reliable operation of the application.

Result:
![Animation2](https://github.com/doakey3/blender-typewriter-addon/assets/31864321/cfe80e6d-d8fb-48d7-bd8d-0d009ae359a0)
Output frames:
![frames2](https://github.com/doakey3/blender-typewriter-addon/assets/31864321/8b23eebb-599f-4cc8-9190-78a308809ffc)
All are OK!